### PR TITLE
Update parallel computing toolbox calls

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -19,12 +19,13 @@ All that being said, if any questions/concerns/bugs arise, please feel free to e
 
 
 
-1)	To run this code, you will first have to compile the associated mex files contained in this repository.  In order to do this, type
+1a)	To run this code, you will first have to compile the associated mex files contained in this repository.  In order to do this, type
 
 	compile_mex_files
 
 in the MATLAB command prompt from the main directory.  You will need to have your mex compiler properly set-up.
 
+1b) Add all directories to your path.
 
 2)	An example run-through of all the portions of the algorithm can be found in runExample.m.  Given a folder of .avi movies (specified as ‘filePath’ at the top of the aforementioned file), this will run through each of the steps in the algorithm.  It should be noted again that this code is not currently tested to work cross-platform or for any movies other than the ones presented in the original paper.
 

--- a/findEmbeddings.m
+++ b/findEmbeddings.m
@@ -21,10 +21,6 @@ function [zValues,outputStatistics] = ...
 % (C) Gordon J. Berman, 2014
 %     Princeton University
 
-    addpath(genpath('./utilities/'));
-    addpath(genpath('./t_sne/'));
-    
-    
     if nargin < 4
         parameters = [];
     end

--- a/findEmbeddings.m
+++ b/findEmbeddings.m
@@ -26,15 +26,8 @@ function [zValues,outputStatistics] = ...
     end
     parameters = setRunParameters(parameters);
     
-    
-    
-    if matlabpool('size') ~= parameters.numProcessors;
-        matlabpool close force
-        if parameters.numProcessors > 1
-            matlabpool(parameters.numProcessors);
-        end
-    end
-    
+        
+    setup_parpool(parameters.numProcessors)
     
     
     d = length(trainingData(1,:));
@@ -79,5 +72,5 @@ function [zValues,outputStatistics] = ...
                                 
     
     if parameters.numProcessors > 1  && parameters.closeMatPool
-        matlabpool close
+        close_parpool
     end

--- a/findPosturalEigenmodes.m
+++ b/findPosturalEigenmodes.m
@@ -21,9 +21,6 @@ function [vecs,vals,meanValue] = findPosturalEigenmodes(filePath,pixels,paramete
 %     Princeton University
 
     
-    addpath(genpath('./utilities/'));
-    addpath(genpath('./PCA/'));
-    
     if nargin < 3
         parameters = [];
     end

--- a/findPosturalEigenmodes.m
+++ b/findPosturalEigenmodes.m
@@ -27,13 +27,8 @@ function [vecs,vals,meanValue] = findPosturalEigenmodes(filePath,pixels,paramete
     parameters = setRunParameters(parameters);
     
     
-    if matlabpool('size') ~= parameters.numProcessors;
-        matlabpool close force
-        if parameters.numProcessors > 1
-            matlabpool(parameters.numProcessors);
-        end
-    end
-    
+    setup_parpool(parameters.numProcessors)
+
     
     if iscell(filePath)
         
@@ -64,5 +59,5 @@ function [vecs,vals,meanValue] = findPosturalEigenmodes(filePath,pixels,paramete
     
     
     if parameters.numProcessors > 1 && parameters.closeMatPool
-        matlabpool close
+        close_parpool
     end

--- a/findProjections.m
+++ b/findProjections.m
@@ -21,9 +21,6 @@ function projections = findProjections(filePath,vecs,meanValues,pixels,parameter
 %     Princeton University
 
     
-    addpath(genpath('./utilities/'));
-    addpath(genpath('./PCA/'));
-    
     if nargin < 5
         parameters = [];
     end

--- a/findProjections.m
+++ b/findProjections.m
@@ -27,13 +27,7 @@ function projections = findProjections(filePath,vecs,meanValues,pixels,parameter
     parameters = setRunParameters(parameters);
     
     
-    if matlabpool('size') ~= parameters.numProcessors;
-        matlabpool close force
-        if parameters.numProcessors > 1
-            matlabpool(parameters.numProcessors);
-        end
-    end
-    
+    setup_parpool(parameters.numProcessors)    
     
     %files = findAllImagesInFolders(filePath,'tiff');
     %N = length(files);
@@ -67,7 +61,7 @@ function projections = findProjections(filePath,vecs,meanValues,pixels,parameter
     
         
     if parameters.numProcessors > 1  && parameters.closeMatPool
-        matlabpool close
+        close_parpool
     end
     
     

--- a/findRadonPixels.m
+++ b/findRadonPixels.m
@@ -23,9 +23,6 @@ function [pixels,thetas,means,stDevs,vidObjs] = findRadonPixels(filePath,numToTe
 % (C) Gordon J. Berman, 2014
 %     Princeton University
 
-    addpath(genpath('./utilities/'));
-    addpath(genpath('./PCA/'));
-    
     if nargin < 3
         parameters = [];
     end

--- a/findRadonPixels.m
+++ b/findRadonPixels.m
@@ -29,12 +29,8 @@ function [pixels,thetas,means,stDevs,vidObjs] = findRadonPixels(filePath,numToTe
     parameters = setRunParameters(parameters);
     
     
-    if matlabpool('size') ~= parameters.numProcessors;
-        matlabpool close force
-        if parameters.numProcessors > 1
-            matlabpool(parameters.numProcessors);
-        end
-    end
+    setup_parpool(parameters.numProcessors)
+
     
     numThetas = parameters.num_Radon_Thetas;
     spacing = 180/numThetas;
@@ -77,6 +73,6 @@ function [pixels,thetas,means,stDevs,vidObjs] = findRadonPixels(filePath,numToTe
     
     
     if parameters.numProcessors > 1 && parameters.closeMatPool
-        matlabpool close
+        close_parpool
     end
     

--- a/findWavelets.m
+++ b/findWavelets.m
@@ -34,12 +34,8 @@ function [amplitudes,f] = findWavelets(projections,numModes,parameters)
     end
     
     
-    if matlabpool('size') ~= parameters.numProcessors;
-        matlabpool close force
-        if parameters.numProcessors > 1
-            matlabpool(parameters.numProcessors);
-        end
-    end
+    setup_parpool(parameters.numProcessors)
+
     
     
     omega0 = parameters.omega0;
@@ -61,7 +57,7 @@ function [amplitudes,f] = findWavelets(projections,numModes,parameters)
     
     
     if parameters.numProcessors > 1 && parameters.closeMatPool
-        matlabpool close
+        close_parpool
     end
     
     

--- a/findWavelets.m
+++ b/findWavelets.m
@@ -18,9 +18,6 @@ function [amplitudes,f] = findWavelets(projections,numModes,parameters)
 %     Princeton University
 
     
-    addpath(genpath('./utilities/'));
-    addpath(genpath('./wavelet/'));
-    
     if nargin < 3
         parameters = [];
     end

--- a/runAlignment.m
+++ b/runAlignment.m
@@ -19,10 +19,6 @@ function outputStruct = runAlignment(fileName,outputPath,startImage,finalImage,p
 %     Princeton University
 
 
-    addpath(genpath('./utilities/'));
-    addpath(genpath('./segmentation_alignment/'));
-    
-    
     if ~exist(outputPath,'dir')
         mkdir(outputPath);
     end

--- a/runAlignment.m
+++ b/runAlignment.m
@@ -41,13 +41,8 @@ function outputStruct = runAlignment(fileName,outputPath,startImage,finalImage,p
     parameters = setRunParameters(parameters);
     
     
-    if matlabpool('size') ~= parameters.numProcessors;
-        matlabpool close force
-        if parameters.numProcessors > 1
-            matlabpool(parameters.numProcessors);
-        end
-    end
-    
+    setup_parpool(parameters.numProcessors)
+
     
     [Xs,Ys,angles,areas,~,framesToCheck,svdskipped,areanorm] = ...
         alignImages_Radon_parallel_avi(fileName,startImage,finalImage,...
@@ -66,7 +61,7 @@ function outputStruct = runAlignment(fileName,outputPath,startImage,finalImage,p
     
     
     if parameters.numProcessors > 1 && parameters.closeMatPool
-        matlabpool close
+        close_parpool
     end
     
     

--- a/runEmbeddingSubSampling.m
+++ b/runEmbeddingSubSampling.m
@@ -26,15 +26,8 @@ function [trainingSetData,trainingSetAmps,projectionFiles] = runEmbeddingSubSamp
     end
     parameters = setRunParameters(parameters);
     
-    
-    if matlabpool('size') ~= parameters.numProcessors;
-        matlabpool close force
-        if parameters.numProcessors > 1
-            matlabpool(parameters.numProcessors);
-        end
-    end
-    
-    
+    setup_parpool(parameters.numProcessors)
+
     
     projectionFiles = findAllImagesInFolders(projectionDirectory,'.mat');
     
@@ -67,5 +60,5 @@ function [trainingSetData,trainingSetAmps,projectionFiles] = runEmbeddingSubSamp
     
     
     if parameters.numProcessors > 1  && parameters.closeMatPool
-        matlabpool close
+        close_parpool
     end

--- a/runEmbeddingSubSampling.m
+++ b/runEmbeddingSubSampling.m
@@ -1,5 +1,4 @@
-function [trainingSetData,trainingSetAmps,projectionFiles] = ...
-            runEmbeddingSubSampling(projectionDirectory,parameters)
+function [trainingSetData,trainingSetAmps,projectionFiles] = runEmbeddingSubSampling(projectionDirectory,parameters)
 %runEmbeddingSubSampling generates a training set given a set of .mat files
 %
 %   Input variables:
@@ -21,9 +20,7 @@ function [trainingSetData,trainingSetAmps,projectionFiles] = ...
 % (C) Gordon J. Berman, 2014
 %     Princeton University
     
-    addpath(genpath('./utilities/'));
-    addpath(genpath('./t_sne/'));
-    
+
     if nargin < 2
         parameters = [];
     end

--- a/runExample.m
+++ b/runExample.m
@@ -29,7 +29,7 @@ alignmentDirectory = [filePath '/alignment_files/'];
 if ~exist(alignmentDirectory,'dir')
     mkdir(alignmentDirectory);
 end
-    
+
 
 %run alignment for all files in the directory
 fprintf(1,'Aligning Files\n');

--- a/runExample.m
+++ b/runExample.m
@@ -34,15 +34,15 @@ end
 %run alignment for all files in the directory
 fprintf(1,'Aligning Files\n');
 alignmentFolders = cell(L,1);
-for i=1:L    
+for ii=1:L    
     
-    fprintf(1,'\t Aligning File #%4i out of %4i\n',i,L);
+    fprintf(1,'\t Aligning File #%4i out of %4i\n',ii,L);
     
-    fileNum = [repmat('0',1,numZeros-length(num2str(i))) num2str(i)];
+    fileNum = [repmat('0',1,numZeros-length(num2str(ii))) num2str(ii)];
     tempDirectory = [alignmentDirectory 'alignment_' fileNum '/'];
-    alignmentFolders{i} = tempDirectory;
+    alignmentFolders{ii} = tempDirectory;
     
-    outputStruct = runAlignment(imageFiles{i},tempDirectory,firstFrame,lastFrame,parameters);
+    outputStruct = runAlignment(imageFiles{ii},tempDirectory,firstFrame,lastFrame,parameters);
     
     save([tempDirectory 'outputStruct.mat'],'outputStruct');
     
@@ -178,16 +178,5 @@ end
 
 
 
-
-matlabpool close
-
-
-
-
-
-
-
-
-
-
+close_parpool
 

--- a/runExample_noSubsampling.m
+++ b/runExample_noSubsampling.m
@@ -43,10 +43,10 @@ fprintf(1,'Aligning Files\n');
 alignmentFolders = cell(L,1);
 i=1;
 
-fileNum = [repmat('0',1,numZeros-length(num2str(i))) num2str(i)];
+fileNum = [repmat('0',1,numZeros-length(num2str(ii))) num2str(ii)];
 tempDirectory = [alignmentDirectory 'alignment_' fileNum '/'];
-alignmentFolders{i} = tempDirectory;
-outputStruct = runAlignment(imageFiles{i},tempDirectory,firstFrame,lastFrame,parameters);
+alignmentFolders{ii} = tempDirectory;
+outputStruct = runAlignment(imageFiles{ii},tempDirectory,firstFrame,lastFrame,parameters);
 
 save([tempDirectory 'outputStruct.mat'],'outputStruct');
 
@@ -84,11 +84,11 @@ if ~exist(projectionsDirectory,'dir')
 end
 
 fprintf(1,'Finding Projections\n');
-i=1;
-projections = findProjections(alignmentFolders{i},vecs,meanValues,pixels,parameters);
+ii=1;
+projections = findProjections(alignmentFolders{ii},vecs,meanValues,pixels,parameters);
 
-fileNum = [repmat('0',1,numZeros-length(num2str(i))) num2str(i)];
-fileName = imageFiles{i};
+fileNum = [repmat('0',1,numZeros-length(num2str(ii))) num2str(ii)];
+fileName = imageFiles{ii};
 
 save([projectionsDirectory 'projections_' fileNum '.mat'],'projections','fileName');
 
@@ -118,7 +118,7 @@ fprintf(1,'Finding t-SNE Embedding for all Data\n');
 embeddingValues = cell(L,1);
 i=1;
 
-[embeddingValues{i},~] = findEmbeddings(data,trainingSetData,trainingEmbedding,parameters);
+[embeddingValues{ii},~] = findEmbeddings(data,trainingSetData,trainingEmbedding,parameters);
 
 
 
@@ -138,7 +138,7 @@ rangeVals = [-maxVal maxVal];
 
 densities = zeros(numPoints,numPoints,L);
 for i=1:L
-    [~,densities(:,:,i)] = findPointDensity(embeddingValues{i},sigma,numPoints,rangeVals);
+    [~,densities(:,:,ii)] = findPointDensity(embeddingValues{ii},sigma,numPoints,rangeVals);
 end
 
 
@@ -158,26 +158,15 @@ N = ceil(sqrt(L));
 M = ceil(L/N);
 maxDensity = max(densities(:));
 for i=1:L
-    subplot(M,N,i)
-    imagesc(xx,xx,densities(:,:,i))
+    subplot(M,N,ii)
+    imagesc(xx,xx,densities(:,:,ii))
     axis equal tight off xy
     caxis([0 maxDensity * .8])
     colormap(jet)
-    title(['Data Set #' num2str(i)],'fontsize',12,'fontweight','bold');
+    title(['Data Set #' num2str(ii)],'fontsize',12,'fontweight','bold');
 end
 
 
 
-
-matlabpool close
-
-
-
-
-
-
-
-
-
-
+close_parpool
 

--- a/run_tSne.m
+++ b/run_tSne.m
@@ -19,10 +19,6 @@ function [yData,betas,P,errors] = run_tSne(data,parameters)
 % (C) Gordon J. Berman, 2014
 %     Princeton University
 
-
-    addpath(genpath('./utilities/'));
-    addpath(genpath('./t_sne/'));
-    
     if nargin < 2
         parameters = [];
     end

--- a/segmentation_alignment/alignImages_Radon_parallel_avi.m
+++ b/segmentation_alignment/alignImages_Radon_parallel_avi.m
@@ -85,8 +85,9 @@ function [Xs,Ys,angles,areas,parameters,framesToCheck,svdskipped,areanorm] = ...
     basisSize = sum(basisImage(:)>0);
     s = size(basisImage);
     currentImageSet = uint8(zeros(s(1),s(2),parameters.areaNormalizationNumber));
-    parfor i=1:length(idx)
-        currentImageSet(:,:,i) = read(vidObj,idx(i));
+
+    parfor ii=1:length(idx)
+        currentImageSet(:,:,ii) = read(vidObj,idx(ii));
     end
     
     if bodyThreshold < 0   

--- a/segmentation_alignment/alignImages_Radon_parallel_avi.m
+++ b/segmentation_alignment/alignImages_Radon_parallel_avi.m
@@ -84,10 +84,15 @@ function [Xs,Ys,angles,areas,parameters,framesToCheck,svdskipped,areanorm] = ...
     idx = randi([startImage,nFrames],[parameters.areaNormalizationNumber,1]);
     basisSize = sum(basisImage(:)>0);
     s = size(basisImage);
+
+    temp=vidObj.read(idx(1));
+    if size(temp,3)>1
+        fprintf('WARNING: your movie is RGB. Likely this will cause a failure.\n')
+    end
     currentImageSet = uint8(zeros(s(1),s(2),parameters.areaNormalizationNumber));
 
     parfor ii=1:length(idx)
-        currentImageSet(:,:,ii) = read(vidObj,idx(ii));
+        currentImageSet(:,:,ii) = vidObj.read(idx(ii));
     end
     
     if bodyThreshold < 0   

--- a/t_sne/file_embeddingSubSampling.m
+++ b/t_sne/file_embeddingSubSampling.m
@@ -25,8 +25,6 @@ function [yData,signalData,signalIdx,signalAmps] = ...
     perplexity = parameters.training_perplexity;
     numPoints = parameters.training_numPoints;
     
-    addpath(genpath('./wavelet/'));
-    
     fprintf(1,'\t Loading Projections\n');
     load(projectionFile,'projections');
     

--- a/utilities/close_parpool.m
+++ b/utilities/close_parpool.m
@@ -1,0 +1,24 @@
+function close_parpool
+    % close the parallel pool in the correct for different versions 
+    % of MATLAB.
+    %
+    % function close_parpool
+    %
+    % Rob Campbell - TENSS 2017
+
+
+    % Is the parallel computing toolbox installed?
+    if isempty(ver('distcomp'))
+        fprintf('No parallel computing toolbox installed\n')
+        return
+    end
+
+
+    % Start the desired number of workers. Delete existing pool with wrong number
+    % of workers if needed.
+    if verLessThan('matlab','8.3')
+        matlabpool close
+    else
+        delete(gcp('nocreate'))
+    end
+        

--- a/utilities/setup_parpool.m
+++ b/utilities/setup_parpool.m
@@ -1,0 +1,45 @@
+function setup_parpool(desiredPoolSize)
+    % Set up a parallel pool of the desired number of workers
+    %
+    %  function setup_parpool(desiredPoolSize)
+    %
+    % Runs the correct parallel pool setup function for different versions 
+    % of MATLAB.
+    %
+    % Inputs
+    % desiredPoolSize - an integer specifying the desired number of workers
+    %
+    %
+    % Rob Campbell - TENSS 2017
+
+
+    % Is the parallel computing toolbox installed?
+    if isempty(ver('distcomp'))
+        fprintf('No parallel computing toolbox installed\n')
+        return
+    end
+
+
+    % Start the desired number of workers. Delete existing pool with wrong number
+    % of workers if needed.
+    if verLessThan('matlab','8.3')
+
+        if matlabpool('size') ~= desiredPoolSize;
+            matlabpool close force
+            if desiredPoolSize > 1
+                matlabpool(desiredPoolSize);
+            end
+        end
+
+    else
+
+        g=gcp;
+        if g.NumWorkers ~= desiredPoolSize
+            delete(gcp('nocreate'))
+            if desiredPoolSize > 1
+                parpool(desiredPoolSize);
+            end
+        end
+
+    end
+        


### PR DESCRIPTION
I updated the calls for starting the parallel computing toolbox, as this has changed since the version of MATLAB you used. To make it easier to handle this, I created a dedicated function for handling the starting and stopping of the pool. 

I removed the relative `addpath` statements, since these can be a problem if the user adds the functions to the path. It's better to just add to the path once than to attempt to add stuff each time a function is run. 